### PR TITLE
whiny_validation loads ActiveRecord too early and breaks the configurations applied to ActiveRecord

### DIFF
--- a/lib/whiny_validation.rb
+++ b/lib/whiny_validation.rb
@@ -32,8 +32,10 @@ module WhinyValidation
   WhinyValidation::LogSubscriber.attach_to :whiny_validation
 end
 
-module ActiveRecord
-  class Base
-    include WhinyValidation
+if defined?(ActiveRecord)
+  # ActiveRecord is dependent on ActiveSupport so we are good
+  # with calling ActiveSupport
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::Base.send(:include, WhinyValidation)
   end
-end if defined? ActiveRecord
+end


### PR DESCRIPTION
This is how it is supposed to work:

1. config/application.rb is called In the config/application.rb there is a load_defaults "5.0" or load_defaults "5.1" depending on the version
2. By default the option active_record.belongs_to_required_by_default is set to 'true' by Rails
3. Rails allows us to override this option in config/initializers/new_framework_defaults_5_1.rb with Rails.application.config.active_record.belongs_to_required_by_default = false This means that the belongs_to option is not requied
4. After config/application.rb the config/initializers/new_framework_defaults_5_1.rb is called
5. The option is applied to ActiveRecord and the belongs_to are false

But if we have whiny_validation we break the cycle. whiny_validation loads ActiveRecord before the initializers This happens because of:

```ruby
# lib/whiny_validation.rb

module ActiveRecord
  class Base
    include WhinyValidation
  end
end
```

Because of this the order of load is:

1. config/application.rb
2. then whiny_validation which loads ActiveRecord
3. then config/initializers/new_framework_defaults_5_1.rb

At step 2 whiny_validation loads the ActiveRecord and this applies the default configuration to ActiveRecord. Then if we set a different value to the configuration in config/initializers/new_framework_defaults_5_1.rb it will not matter as ActiveRecord is already loaded.

This is a hard to debug case where configurtions from initializers are not correctly applied. The solution is to use the ActiveSupport.on_load(:active_record) method. (Thanks Mihail Kirilov for poiting this out) like:

```ruby
if defined?(ActiveRecord)
  ActiveSupport.on_load(:active_record) do
    ActiveRecord::Base.send(:include, WhinyValidation)
  end
end
```

Here is a script to reproduce the issue:

```bash
rvm use ruby-2.7.6
gem install rails -v 5.1.7
rails _5.1.7_ new whiny_pr
cd whiny_pr
rails g model User name:string
rails g model Article user:references
rake db:create
rake db:migrate
echo "task :belongs_to_test=> :environment do
  puts Article.create!
end" > lib/tasks/belongs_to_test.rake
rake belongs_to_test
# An error occurs which is ActiveRecord::RecordInvalid: Validation failed: User must exist
# rake aborted!
# ActiveRecord::RecordInvalid: Validation failed: User must exist
```

```bash
# No we make the belongs to optional
echo '
# Require `belongs_to` associations by default. Previous versions had false. Rails.application.config.active_record.belongs_to_required_by_default = false ' > config/initializers/new_framework_defaults_5_1.rb
```

```bash
# Execute the rake again an it will not fail
rake belongs_to_test
'#<Article:0x00000001034d1a08>'

# There is an article created. Everything works as expected. # The belongs_to is optional by default
```

# Add whiny_validation

```bash
echo 'gem "whiny_validation"' >> Gemfile
bundle install
```

# Execute the take again

```bash
rake belongs_to_test

# The rake fails with
# rake aborted!
# ActiveRecord::RecordInvalid: Validation failed: User must exist

```

# clone the whiny_validation repo

```bash
cd ..
git clone git@github.com:BMorearty/whiny_validation.git cd whiny_validation
```

# Open whiny_validation

```bash
nano lib/whiny_validation.rb
```

# Change the following fragment

```ruby
module ActiveRecord
  class Base
    include WhinyValidation
end
end if defined? ActiveRecord
```

with

```ruby
if defined?(ActiveRecord)
  ActiveSupport.on_load(:active_record) do
    ActiveRecord::Base.send(:include, WhinyValidation)
  end
end
```

# Change dependecy in Gemfile to point to local get

```bash
cd ..
cd whiny_pr

# Remove the whiny_validation dependency from Gemfile sed -i -e "/whiny_validation/d" Gemfile

# Add the new dependency
echo "
gem 'whiny_validation', path: '$(readlink -f $(pwd)/..)/whiny_validation' " >> Gemfile

bundle install
```

# Ruby rake again
```bash
rake belongs_to_test
# The test is executed successfully
```