### PR TITLE
Add compatibility with ActiveSupport 7.1+

### DIFF
--- a/lib/whiny_validation.rb
+++ b/lib/whiny_validation.rb
@@ -18,9 +18,17 @@ module WhinyValidation
   end
 
   class LogSubscriber < ActiveSupport::LogSubscriber
+    def color_mode_options
+      if ActiveSupport.gem_version < Gem::Version.new("7.1.0")
+        true
+      else
+        { bold: true }
+      end
+    end
+
     def validation_failed(event)
       send(WhinyValidation.configuration.log_level) do
-        name = color("Validation failed", YELLOW, true)
+        name = color("Validation failed", YELLOW, color_mode_options)
         object = event.payload[:object]
         error_messages = color(event.payload[:error_messages].map{|message|"    => #{message}"}.join("\n"), YELLOW)
 


### PR DESCRIPTION
# Summary

This adds compatibility with ActiveSupport 7.1+ by adding logic to use the appropriate options format when calling
ActiveSupport::LogSubscriber#color.

# Problem

In the context of Rails 7.1, WhinyValidation triggers: "DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. `color("my text", :red, bold: true)`)." The problem is [this line](https://github.com/BMorearty/whiny_validation/blob/3be06a860949e50c099db18ccd7e4bd8c258b54d/lib/whiny_validation.rb#L23):

```
name = color("Validation failed", YELLOW, true)
```

The deprecation warning can be resolved by making that last argument a hash: `bold: true`.